### PR TITLE
Set svelte:compiler as weak dependency and validate svelte npm dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+import { checkNpmVersions } from 'meteor/tmeasday:check-npm-versions';
+
+if(Meteor.isServer){
+  checkNpmVersions({
+    'svelte': ">=3.25.0"
+  }, 'rdb:svelte-meteor-data');
+  // this require is here only to make sure we can validate the npm dependency above
+  require(`svelte/package.json`)
+}
 export { default as useTracker } from './use-tracker';
 
 import './subscribe';

--- a/package.js
+++ b/package.js
@@ -10,7 +10,8 @@ Package.onUse(function(api) {
   api.versionsFrom('1.8');
   api.use('ecmascript');
   api.use('tracker');
-  api.use('svelte:compiler@3.31.2 || 3.25.0');
+  api.use('tmeasday:check-npm-versions@1.0.2');
+  api.use('svelte:compiler', {weak: true});
   api.use('reactive-var', {weak: true});
   api.use('session', 'client', {weak: true});
   api.use('mongo', {weak: true});
@@ -21,6 +22,7 @@ Package.onTest(function(api) {
   api.use('ecmascript');
   api.use('tinytest');
   api.use('rdb:svelte-meteor-data');
+  api.use('tmeasday:check-npm-versions@1.0.2');
   api.use('reactive-var');
   api.use('session', 'client');
   api.addFiles('reactive-var.tests.js');


### PR DESCRIPTION
Set svelte:compiler as weak dependency and validate svelte npm dependency existence.

Solves issue #14 and makes it possible to use this package with the latest svelte compiler.

Meteor 2.6.1 and on introduces an update on Babel set of dependencies, which makes the current svelte version imported by this package break with a missing "sourcemap" field error.

As this package is included in our skeleton, it's important that it works always with the latest version of svelt, so I think it's also a good addition.

Thanks for your great work here!